### PR TITLE
Exists morphed validation rule

### DIFF
--- a/Controllers/AbstractRelatedEntityController.php
+++ b/Controllers/AbstractRelatedEntityController.php
@@ -80,6 +80,7 @@ abstract class AbstractRelatedEntityController extends ApiController
      * Override this method to provide custom pivot validation rules.
      *
      * @param null $entityId
+     * @param array $requestEntity
      * @return array
      */
     protected function getValidationRules($entityId = null, array $requestEntity = [])

--- a/Controllers/ChildEntityController.php
+++ b/Controllers/ChildEntityController.php
@@ -311,6 +311,7 @@ abstract class ChildEntityController extends AbstractRelatedEntityController
 
     /**
      * @param null $entityId
+     * @param array $requestEntity
      * @return array
      */
     protected function getValidationRules($entityId = null, array $requestEntity = [])

--- a/Controllers/EntityController.php
+++ b/Controllers/EntityController.php
@@ -523,6 +523,8 @@ abstract class EntityController extends ApiController
     }
 
     /**
+     * @param null $entityId
+     * @param array $requestEntity
      * @return array
      */
     protected function getValidationRules($entityKey = null, array $requestEntity = [])

--- a/Model/Model/BaseModel.php
+++ b/Model/Model/BaseModel.php
@@ -49,6 +49,7 @@ abstract class BaseModel extends Model
 
     /**
      * @param null $entityId
+     * @param array $requestEntity
      * @return array
      */
     public static function getValidationRules($entityId = null, array $requestEntity = [])

--- a/Providers/AppServiceProvider.php
+++ b/Providers/AppServiceProvider.php
@@ -33,6 +33,7 @@ class AppServiceProvider extends ServiceProvider
             'decoded_json'         => 'The :attribute must be an object or an array',
             'alpha_dash_space'     => 'The :attribute may only contain letters, numbers, dashes and spaces.',
             'supported_region'     => 'The :attribute must be a supported region. Supported region codes are ('.implode(', ', array_pluck(config('regions.supported'), 'code')).')',
+            'exists_morphed'       => 'The :attribute must exists in corresponding table'
         ];
 
         $this->app->extend('validator', function (Factory $validator) use ($spiraMessages) {

--- a/Providers/AppServiceProvider.php
+++ b/Providers/AppServiceProvider.php
@@ -33,7 +33,7 @@ class AppServiceProvider extends ServiceProvider
             'decoded_json'         => 'The :attribute must be an object or an array',
             'alpha_dash_space'     => 'The :attribute may only contain letters, numbers, dashes and spaces.',
             'supported_region'     => 'The :attribute must be a supported region. Supported region codes are ('.implode(', ', array_pluck(config('regions.supported'), 'code')).')',
-            'exists_morphed'       => 'The :attribute must exists in corresponding table'
+            'exists_morphed'       => 'The :attribute must exists in corresponding table',
         ];
 
         $this->app->extend('validator', function (Factory $validator) use ($spiraMessages) {

--- a/Validation/SpiraValidator.php
+++ b/Validation/SpiraValidator.php
@@ -17,6 +17,32 @@ use Spira\Core\Model\Datasets\Countries;
 
 class SpiraValidator extends Validator
 {
+    /**
+     * Rule for validation existance of morphed item
+     * Parameters are: column containing class or class name, column if primary key is not used, where conditions
+     */
+    public function validateExistsMorphed($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'exists_morphed');
+
+        if (!Uuid::isValid($value)) {
+            return false;
+        }
+
+        $class = Arr::get($this->data, $parameters[0], $parameters[0]);
+        if (empty($class) || !class_exists($class)) {
+            return false;
+        }
+
+        $column = Arr::get($parameters, 1) ?: call_user_func_array("$class::getPrimaryKey", []);
+        $table  = call_user_func_array("$class::getTableName", []);
+
+        $parameters[0] = $table;
+        $parameters[1] = $column;
+
+        return $this->validateExists($attribute, $value, $parameters);
+    }
+
     public function validateDecimal($attribute, $value, $parameters)
     {
         return is_float($value) || is_int($value);

--- a/Validation/SpiraValidator.php
+++ b/Validation/SpiraValidator.php
@@ -19,23 +19,23 @@ class SpiraValidator extends Validator
 {
     /**
      * Rule for validation existance of morphed item
-     * Parameters are: column containing class or class name, column if primary key is not used, where conditions
+     * Parameters are: column containing class or class name, column if primary key is not used, where conditions.
      */
     public function validateExistsMorphed($attribute, $value, $parameters)
     {
         $this->requireParameterCount(1, $parameters, 'exists_morphed');
 
-        if (!Uuid::isValid($value)) {
+        if (! Uuid::isValid($value)) {
             return false;
         }
 
         $class = Arr::get($this->data, $parameters[0], $parameters[0]);
-        if (empty($class) || !class_exists($class)) {
+        if (empty($class) || ! class_exists($class)) {
             return false;
         }
 
         $column = Arr::get($parameters, 1) ?: call_user_func_array("$class::getPrimaryKey", []);
-        $table  = call_user_func_array("$class::getTableName", []);
+        $table = call_user_func_array("$class::getTableName", []);
 
         $parameters[0] = $table;
         $parameters[1] = $column;

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     "barryvdh/laravel-ide-helper": "dev-master"
   },
   "autoload": {
-    "psr-4": { "Spira\\Core\\": "" }
+    "psr-4": { "Spira\\Core\\": "" },
+    "classmap": ["database/"]
   },
   "config": {
     "preferred-install": "dist"

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -11,7 +11,10 @@
 namespace Spira\Core\tests;
 
 use Illuminate\Validation\Factory;
+use Mockery\MockInterface;
 use Rhumsaa\Uuid\Uuid;
+use Spira\Core\Model\Test\SecondTestEntity;
+use Spira\Core\Model\Test\TestEntity;
 use Spira\Core\Validation\SpiraValidator;
 
 class ValidatorTest extends TestCase
@@ -33,6 +36,37 @@ class ValidatorTest extends TestCase
         $data = ['decimal' => 'foo'];
         $validation = $this->validator->make($data, ['decimal' => 'decimal']);
         $this->assertInstanceOf(SpiraValidator::class, $validation);
+    }
+
+    /**
+     * @dataProvider dataExistsMorphedValidation
+     */
+    public function testExistsMorphedValidation($rule, $passes = true)
+    {
+        $item      = $this->getFactory(TestEntity::class)->customize(['integer' => 123])->create();
+        $validator = $this->validator->make(
+            ['item_id' => $item->entity_id, 'item_type' => TestEntity::class],
+            ['item_id' => $rule]
+        );
+
+        $this->assertEquals($passes, $validator->passes());
+
+        if (!$passes) {
+            $this->assertEquals('The item id must exists in corresponding table', $validator->messages()->get('item_id')[0]);
+        }
+    }
+
+    public function dataExistsMorphedValidation()
+    {
+        return [
+            ['exists_morphed:item_type', true],
+            ['exists_morphed:item_type,entity_id', true],
+            ['exists_morphed:item_type,hash', false],
+            ['exists_morphed:item_type,,integer,123', true],
+            ['exists_morphed:item_type,entity_id,integer,321', false],
+            ['exists_morphed:' . TestEntity::class, true],
+            ['exists_morphed:' . SecondTestEntity::class, false],
+        ];
     }
 
     public function testPassingDecimalValidation()

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -11,7 +11,6 @@
 namespace Spira\Core\tests;
 
 use Illuminate\Validation\Factory;
-use Mockery\MockInterface;
 use Rhumsaa\Uuid\Uuid;
 use Spira\Core\Model\Test\SecondTestEntity;
 use Spira\Core\Model\Test\TestEntity;
@@ -43,7 +42,7 @@ class ValidatorTest extends TestCase
      */
     public function testExistsMorphedValidation($rule, $passes = true)
     {
-        $item      = $this->getFactory(TestEntity::class)->customize(['integer' => 123])->create();
+        $item = $this->getFactory(TestEntity::class)->customize(['integer' => 123])->create();
         $validator = $this->validator->make(
             ['item_id' => $item->entity_id, 'item_type' => TestEntity::class],
             ['item_id' => $rule]
@@ -51,7 +50,7 @@ class ValidatorTest extends TestCase
 
         $this->assertEquals($passes, $validator->passes());
 
-        if (!$passes) {
+        if (! $passes) {
             $this->assertEquals('The item id must exists in corresponding table', $validator->messages()->get('item_id')[0]);
         }
     }
@@ -64,8 +63,8 @@ class ValidatorTest extends TestCase
             ['exists_morphed:item_type,hash', false],
             ['exists_morphed:item_type,,integer,123', true],
             ['exists_morphed:item_type,entity_id,integer,321', false],
-            ['exists_morphed:' . TestEntity::class, true],
-            ['exists_morphed:' . SecondTestEntity::class, false],
+            ['exists_morphed:'.TestEntity::class, true],
+            ['exists_morphed:'.SecondTestEntity::class, false],
         ];
     }
 


### PR DESCRIPTION
Main feature: exists_morphed validation rule. Checks persistance of morphTo relation item in database.
Additional: fixed PHPDoc for getValidationRule method, added classmap of database folder to composer.json.
