### PR TITLE
LinkedEntityController refactoring

### DIFF
--- a/Controllers/AbstractRelatedEntityController.php
+++ b/Controllers/AbstractRelatedEntityController.php
@@ -151,7 +151,7 @@ abstract class AbstractRelatedEntityController extends ApiController
     protected function findOrNewChildEntity($id, BaseModel $parent)
     {
         try {
-            return $this->getRelation($parent)->findOrFail($id);
+            return $this->fetchChildFromRelation($id, $parent);
         } catch (ModelNotFoundException $e) {
             return $this->getChildModel()->newInstance();
         }
@@ -165,10 +165,19 @@ abstract class AbstractRelatedEntityController extends ApiController
     protected function findOrFailChildEntity($id, BaseModel $parent)
     {
         try {
-            return $this->getRelation($parent)->findOrFail($id);
+            return $this->fetchChildFromRelation($id, $parent);
         } catch (ModelNotFoundException $e) {
             throw $this->notFoundException($this->getChildModel()->getKeyName());
         }
+    }
+
+    /**
+     * @return BaseModel
+     * @throws ModelNotFoundException
+     */
+    protected function fetchChildFromRelation($id, BaseModel $parent)
+    {
+        return $this->getRelation($parent)->findOrFail($id);
     }
 
     /**

--- a/Controllers/LinkedEntityController.php
+++ b/Controllers/LinkedEntityController.php
@@ -11,6 +11,7 @@
 namespace Spira\Core\Controllers;
 
 use Illuminate\Http\Request;
+use Spira\Core\Model\Model\BaseModel;
 use Spira\Core\Responder\Response\ApiResponse;
 
 abstract class LinkedEntityController extends AbstractRelatedEntityController
@@ -32,11 +33,16 @@ abstract class LinkedEntityController extends AbstractRelatedEntityController
     public function attachOne(Request $request, $id, $childId)
     {
         $parent = $this->findParentEntity($id);
-        $childModel = $this->findOrNewChildEntity($childId, $parent);
 
         $requestEntity = $request->json()->all();
-        $this->validateRequest($requestEntity, $this->getValidationRules($childId, $requestEntity), $childModel, true);
-        $childModel->fill($requestEntity);
+        if (!empty($requestEntity)) {
+            $childModel = $this->findOrNewChildEntity($childId, $parent);
+            $this->validateRequest($requestEntity, $this->getValidationRules($childId, $requestEntity), $childModel, true);
+            $childModel->fill($requestEntity)->save();
+        } else {
+            $childModel = $this->findOrFailChildEntity($childId, $parent);
+        }
+
         $this->checkPermission(static::class.'@attachOne', ['model' => $parent, 'children' => $childModel]);
 
         $this->getRelation($parent)->attach($childModel, $this->getPivotValues($childModel));
@@ -101,5 +107,10 @@ abstract class LinkedEntityController extends AbstractRelatedEntityController
         })->toArray();
 
         return $this->getResponse()->collection($responseCollection, ApiResponse::HTTP_CREATED);
+    }
+
+    protected function fetchChildFromRelation($id, BaseModel $parent)
+    {
+        return $this->getRelation($parent)->getModel()->findOrFail($id);
     }
 }

--- a/Controllers/LinkedEntityController.php
+++ b/Controllers/LinkedEntityController.php
@@ -35,7 +35,7 @@ abstract class LinkedEntityController extends AbstractRelatedEntityController
         $parent = $this->findParentEntity($id);
 
         $requestEntity = $request->json()->all();
-        if (!empty($requestEntity)) {
+        if (! empty($requestEntity)) {
             $childModel = $this->findOrNewChildEntity($childId, $parent);
             $this->validateRequest($requestEntity, $this->getValidationRules($childId, $requestEntity), $childModel, true);
             $childModel->fill($requestEntity)->save();

--- a/tests/integration/LinkedEntityTest.php
+++ b/tests/integration/LinkedEntityTest.php
@@ -44,9 +44,9 @@ class LinkedEntityTest extends TestCase
     public function testAttachOne()
     {
         /** @var $entity TestEntity */
-        $entity  = $this->getFactory(TestEntity::class)->create();
+        $entity = $this->getFactory(TestEntity::class)->create();
         $factory = $this->getFactory(SecondTestEntity::class);
-        $second  = $factory->create();
+        $second = $factory->create();
 
         $transformed = $factory->transformed();
         $transformed['value'] = 'ololo';

--- a/tests/integration/LinkedEntityTestController.php
+++ b/tests/integration/LinkedEntityTestController.php
@@ -16,9 +16,10 @@ use Spira\Core\Responder\Transformers\EloquentModelTransformer;
 
 class LinkedEntityTestController extends LinkedEntityController
 {
+    protected $relationName = 'secondTestEntities';
+
     public function __construct(TestEntity $parentModel, EloquentModelTransformer $transformer)
     {
-        $this->relationName = 'secondTestEntities';
         parent::__construct($parentModel, $transformer);
     }
 }


### PR DESCRIPTION
Entity can be linked without entity in request body.
Fixed issue when entity was not saving while attaching many-to-many (putOne).
Deletion of existing but not linked entity does not throws an error.